### PR TITLE
Fix for MySQL compiler complaints and for directory-type file prim shortcuts not working

### DIFF
--- a/src/inc/db.h
+++ b/src/inc/db.h
@@ -18,7 +18,6 @@
 
 #ifdef SQL_SUPPORT
 #include <mysql/mysql.h>
-#include <mysql/mysql_version.h>
 #endif
 
 #ifdef USE_SSL

--- a/src/p_file.c
+++ b/src/p_file.c
@@ -84,9 +84,7 @@ parse_token(char *filename)
             tempBuf[i] = *temp;
         i++;
         tempBuf[i] = '\0';
-        strcat(tempBuf2, tempBuf);
-        filename = tempBuf2;
-        return filename;
+        return strcat(tempBuf2, tempBuf);
     }
     if ((temp = strstr(filename, "$HELP/")) != NULL) {
         char tempBuf[BUFFER_LEN] = "";
@@ -98,9 +96,7 @@ parse_token(char *filename)
             tempBuf[i] = *temp;
         i++;
         tempBuf[i] = '\0';
-        strcat(tempBuf2, tempBuf);
-        filename = tempBuf2;
-        return filename;
+        return strcat(tempBuf2, tempBuf);
     }
     if ((temp = strstr(filename, "$MUF/")) != NULL) {
         char tempBuf[BUFFER_LEN] = "";
@@ -112,9 +108,7 @@ parse_token(char *filename)
             tempBuf[i] = *temp;
         i++;
         tempBuf[i] = '\0';
-        strcat(tempBuf2, tempBuf);
-        filename = tempBuf2;
-        return filename;
+        return strcat(tempBuf2, tempBuf);
     }
     if ((temp = strstr(filename, "$LOGS/")) != NULL) {
         char tempBuf[BUFFER_LEN] = "";
@@ -126,9 +120,7 @@ parse_token(char *filename)
             tempBuf[i] = *temp;
         i++;
         tempBuf[i] = '\0';
-        strcat(tempBuf2, tempBuf);
-        filename = tempBuf2;
-        return filename;
+        return strcat(tempBuf2, tempBuf);
     }
     if ((temp = strstr(filename, "$INFO/")) != NULL) {
         char tempBuf[BUFFER_LEN] = "";
@@ -140,9 +132,7 @@ parse_token(char *filename)
             tempBuf[i] = *temp;
         i++;
         tempBuf[i] = '\0';
-        strcat(tempBuf2, tempBuf);
-        filename = tempBuf2;
-        return filename;
+        return strcat(tempBuf2, tempBuf);
     }
     if ((temp = strstr(filename, "$MAN/")) != NULL) {
         char tempBuf[BUFFER_LEN] = "";
@@ -154,9 +144,7 @@ parse_token(char *filename)
             tempBuf[i] = *temp;
         i++;
         tempBuf[i] = '\0';
-        strcat(tempBuf2, tempBuf);
-        filename = tempBuf2;
-        return filename;
+        return strcat(tempBuf2, tempBuf);
     }
     if ((temp = strstr(filename, "$MPIHELP/")) != NULL) {
         char tempBuf[BUFFER_LEN] = "";
@@ -168,9 +156,7 @@ parse_token(char *filename)
             tempBuf[i] = *temp;
         i++;
         tempBuf[i] = '\0';
-        strcat(tempBuf2, tempBuf);
-        filename = tempBuf2;
-        return filename;
+        return strcat(tempBuf2, tempBuf);
     }
     if ((temp = strstr(filename, "$WELCOME/")) != NULL) {
         char tempBuf[BUFFER_LEN] = "";
@@ -182,9 +168,7 @@ parse_token(char *filename)
             tempBuf[i] = *temp;
         i++;
         tempBuf[i] = '\0';
-        strcat(tempBuf2, tempBuf);
-        filename = tempBuf2;
-        return filename;
+        return strcat(tempBuf2, tempBuf);
     }
     if ((temp = strstr(filename, "$PUBLIC_HTML/")) != NULL) {
         char tempBuf[BUFFER_LEN] = "";
@@ -196,9 +180,7 @@ parse_token(char *filename)
             tempBuf[i] = *temp;
         i++;
         tempBuf[i] = '\0';
-        strcat(tempBuf2, tempBuf);
-        filename = tempBuf2;
-        return filename;
+        return strcat(tempBuf2, tempBuf);
     }
     if ((temp = strstr(filename, "$WWW/")) != NULL) {
         char tempBuf[BUFFER_LEN] = "";
@@ -210,9 +192,7 @@ parse_token(char *filename)
             tempBuf[i] = *temp;
         i++;
         tempBuf[i] = '\0';
-        strcat(tempBuf2, tempBuf);
-        filename = tempBuf2;
-        return filename;
+        return strcat(tempBuf2, tempBuf);
     }
     return NULL;
 }

--- a/src/p_mysql.c
+++ b/src/p_mysql.c
@@ -7,7 +7,6 @@
 #include "params.h"
 #ifdef SQL_SUPPORT
 #include <mysql/mysql.h>
-#include <mysql/mysql_version.h>
 #include "db.h"
 #include "tune.h"
 #include "props.h"


### PR DESCRIPTION
I use MariaDB, I don't know if that has anything to do with the errors I'm getting related to the include mysql_version.h. But I removed those two lines because the compiler was telling me that clients shouldn't be using that include.

As for the file prims, this is related to issues discussed in these two links:

https://github.com/protomuck/protomuck/issues/15
https://github.com/protomuck/protomuck/issues/9

So far, this fix has been working wonderfully for me, but I don't know for sure whether it's going to cause problems in cases that are not like mine. My MUCK is very small and I don't make use of anything related to the webserver or pueblo, so I'm hoping that someone who does can confirm that this doesn't cause anything to explode.